### PR TITLE
Fix ImageDataBunch.from_name_re issues a warning

### DIFF
--- a/fastai/vision/image.py
+++ b/fastai/vision/image.py
@@ -537,7 +537,7 @@ def _grid_sample(x:TensorImage, coords:FlowField, mode:str='bilinear', padding_m
         # amount we're resizing by, with 100% extra margin
         d = min(x.shape[1]/coords.shape[1], x.shape[2]/coords.shape[2])/2
         # If we're resizing up by >200%, and we're zooming less than that, interpolate first
-        if d>1 and d>z: x = F.interpolate(x[None], scale_factor=1/d, mode='area')[0]
+        if d>1 and d>z: x = F.interpolate(x[None], scale_factor=1/d, mode='area', recompute_scale_factor=True)[0]
     kwargs = {'mode': mode, 'padding_mode': padding_mode}
     if torch.__version__ > "1.2.0": kwargs['align_corners'] = True
     return F.grid_sample(x[None], coords, **kwargs)[0]


### PR DESCRIPTION
nn.Upsample, used by the RatioResize transform in fastai2’s batch image augmenter, that changed its default behaviour between PyTorch versions 1.4.0 and 1.5.0. Luckily, you can get PyTorch 1.5.0 to behave like 1.4.0 by simply passing it an additional parameter, called “recompute_scale_factor=True” when you call it.

Fixes #2624